### PR TITLE
Issue: Display Docker Host Information in Re... #9

### DIFF
--- a/container_update.sh
+++ b/container_update.sh
@@ -2096,9 +2096,9 @@ Telegram-GenerateMessage() {
     local end_time=$(date +%s)
     stats_execution_time=$((end_time - start_time))
 
-    [ -n "$DCU_REPORT_REAL_HOSTNAME" ]          && hostname="$DCU_REPORT_REAL_HOSTNAME"
-    [ -n "$DCU_REPORT_REAL_IP" ]                && primary_IPaddress="$DCU_REPORT_REAL_IP"
-    [ -n "$DCU_REPORT_REAL_DOCKER_VERSION" ]    && docker_version="$DCU_REPORT_REAL_DOCKER_VERSION"
+    [ -n "$DCU_REPORT_REAL_HOSTNAME" ]          && hostname="$(Telegram-EscapeSpecialChars  "$DCU_REPORT_REAL_HOSTNAME")"
+    [ -n "$DCU_REPORT_REAL_IP" ]                && primary_IPaddress="$(Telegram-EscapeSpecialChars  "$DCU_REPORT_REAL_IP")"
+    [ -n "$DCU_REPORT_REAL_DOCKER_VERSION" ]    && docker_version="$(Telegram-EscapeSpecialChars  "$DCU_REPORT_REAL_DOCKER_VERSION")"
     
     if [ "$report_available" == true ]; then
         message+="🐳 *DOCKER CONTAINER UPDATE REPORT*\n"

--- a/container_update.sh
+++ b/container_update.sh
@@ -4,7 +4,7 @@
 # Automatic Docker Container Updater Script
 #
 # ## Version
-# 2024.05.29-e
+# 2024.05.29-f
 #
 # ## Changelog
 # 2024.05.29-1, janseppenrade2: Implemented functionality to retrieve and display the Docker host's information (hostname, IP address, and Docker version) in the reports when running the Docker Container Updater as a Docker container by passing this information via the environment variables `DCU_REPORT_REAL_HOSTNAME`, `DCU_REPORT_REAL_IP` and `DCU_REPORT_REAL_DOCKER_VERSION`.
@@ -2338,7 +2338,7 @@ Send-TelegramNotification() {
             Write-Log "DEBUG" "          => Successfully sent message: $telegram_api_response"
             break
         else
-            if [ -n "$telegram_api_response" ]; then
+            if [ -z "$telegram_api_response" ]; then
                 curl_response=$($cmd_curl "https://api.telegram.org/")
                 Write-Log "ERROR" "          => Failed to send message: $curl_response"
             else

--- a/container_update.sh
+++ b/container_update.sh
@@ -4,7 +4,7 @@
 # Automatic Docker Container Updater Script
 #
 # ## Version
-# 2024.05.29-b
+# 2024.05.29-d
 #
 # ## Changelog
 # 2024.05.29-1, janseppenrade2: Implemented functionality to retrieve and display the Docker host's information (hostname, IP address, and Docker version) in the reports when running the Docker Container Updater as a Docker container by passing this information via the environment variables `DCU_REPORT_REAL_HOSTNAME`, `DCU_REPORT_REAL_IP` and `DCU_REPORT_REAL_DOCKER_VERSION`.
@@ -2096,9 +2096,9 @@ Telegram-GenerateMessage() {
     local end_time=$(date +%s)
     stats_execution_time=$((end_time - start_time))
 
-    [ -n "$DCU_REPORT_REAL_HOSTNAME" ]          && hostname="$(Telegram-EscapeSpecialChars  "$DCU_REPORT_REAL_HOSTNAME")"
-    [ -n "$DCU_REPORT_REAL_IP" ]                && primary_IPaddress="$(Telegram-EscapeSpecialChars  "$DCU_REPORT_REAL_IP")"
-    [ -n "$DCU_REPORT_REAL_DOCKER_VERSION" ]    && docker_version="$(Telegram-EscapeSpecialChars  "$DCU_REPORT_REAL_DOCKER_VERSION")"
+    [ -n "$DCU_REPORT_REAL_HOSTNAME" ]          && hostname="$(Telegram-EscapeSpecialChars "$DCU_REPORT_REAL_HOSTNAME")"
+    [ -n "$DCU_REPORT_REAL_IP" ]                && primary_IPaddress="$(Telegram-EscapeSpecialChars "$DCU_REPORT_REAL_IP")"
+    [ -n "$DCU_REPORT_REAL_DOCKER_VERSION" ]    && docker_version="$(Telegram-EscapeSpecialChars "$DCU_REPORT_REAL_DOCKER_VERSION")"
     
     if [ "$report_available" == true ]; then
         message+="🐳 *DOCKER CONTAINER UPDATE REPORT*\n"
@@ -2321,7 +2321,7 @@ Send-TelegramNotification() {
     local retry_interval=$(Read-INI "$configFile" "telegram" "retry_interval")
     local retry_limit=$(Read-INI "$configFile" "telegram" "retry_limit")
     local telegram_api_response=""
-    local telegram_sendMessage_command="$cmd_curl -s -X POST \"https://api.telegram.org/bot$bot_token/sendMessage\" -H \"Content-Type: application/json\" -d '{ \"chat_id\": "\'$chat_id\'", \"text\": "\'"$message"\'", \"parse_mode\": \"MarkdownV2\" }'"
+    local telegram_sendMessage_command="$cmd_curl -s -X POST \"https://api.telegram.org/bot$bot_token/sendMessage\" -H \"Content-Type: application/json\" -d '{ \"chat_id\": "$chat_id", \"text\": \"$message\", \"parse_mode\": \"MarkdownV2\" }'"
 
     for ((i = 1; i <= retry_limit; i++)); do
 
@@ -2334,7 +2334,7 @@ Send-TelegramNotification() {
         telegram_api_response=$($cmd_curl -s -X POST "https://api.telegram.org/bot$bot_token/sendMessage" -H "Content-Type: application/json" -d '{ "chat_id": "'$chat_id'", "text": "'"$message"'", "parse_mode": "MarkdownV2" }')
         
         if [ "$(echo "$telegram_api_response" | $cmd_jq -r '.ok')" = "true" ]; then
-            Write-Log "DEBUG" "          => Successfully sent message"
+            Write-Log "DEBUG" "          => Successfully sent message: $telegram_api_response"
             break
         else
             Write-Log "ERROR" "          => Failed to send message: $telegram_api_response"

--- a/container_update.sh
+++ b/container_update.sh
@@ -4,7 +4,7 @@
 # Automatic Docker Container Updater Script
 #
 # ## Version
-# 2024.05.29-f
+# 2024.05.29-g
 #
 # ## Changelog
 # 2024.05.29-1, janseppenrade2: Implemented functionality to retrieve and display the Docker host's information (hostname, IP address, and Docker version) in the reports when running the Docker Container Updater as a Docker container by passing this information via the environment variables `DCU_REPORT_REAL_HOSTNAME`, `DCU_REPORT_REAL_IP` and `DCU_REPORT_REAL_DOCKER_VERSION`.
@@ -2339,7 +2339,7 @@ Send-TelegramNotification() {
             break
         else
             if [ -z "$telegram_api_response" ]; then
-                curl_response=$($cmd_curl "https://api.telegram.org/")
+                curl_response=$($cmd_curl -Isv "https://api.telegram.org/")
                 Write-Log "ERROR" "          => Failed to send message: $curl_response"
             else
                 Write-Log "ERROR" "          => Failed to send message: $telegram_api_response"

--- a/container_update.sh
+++ b/container_update.sh
@@ -4,7 +4,7 @@
 # Automatic Docker Container Updater Script
 #
 # ## Version
-# 2024.05.29-g
+# 2024.05.29-1
 #
 # ## Changelog
 # 2024.05.29-1, janseppenrade2: Implemented functionality to retrieve and display the Docker host's information (hostname, IP address, and Docker version) in the reports when running the Docker Container Updater as a Docker container by passing this information via the environment variables `DCU_REPORT_REAL_HOSTNAME`, `DCU_REPORT_REAL_IP` and `DCU_REPORT_REAL_DOCKER_VERSION`.

--- a/container_update.sh
+++ b/container_update.sh
@@ -4,9 +4,10 @@
 # Automatic Docker Container Updater Script
 #
 # ## Version
-# 2024.05.28-2
+# 2024.05.29-a
 #
 # ## Changelog
+# 2024.05.29-1, janseppenrade2: Implemented functionality to retrieve and display the Docker host's information (hostname, IP address, and Docker version) in the reports when running the Docker Container Updater as a Docker container by passing this information via the environment variables `DCU_REPORT_REAL_HOSTNAME`, `DCU_REPORT_REAL_IP` and `DCU_REPORT_REAL_DOCKER_VERSION`.
 # 2024.05.28-2, janseppenrade2: Added support for container attribute "--tty". Prevented self update in case Docker Container Updater is running in a Docker Container.
 # 2024.05.27-3, janseppenrade2: Fixed a bug that caused notifications to be sent even when no action was taken. Additionally, fixed an issue with log file pruning that resulted in the removal of various spaces, which were important for maintaining readability in the log file.
 # 2024.05.27-2, janseppenrade2: Fixed a bug that reported incorrectly listed outstanding updates if an update was already performed during the same script execution.
@@ -2095,6 +2096,10 @@ Telegram-GenerateMessage() {
     local end_time=$(date +%s)
     stats_execution_time=$((end_time - start_time))
 
+    [ -n "$DCU_REPORT_REAL_HOSTNAME" ]          && hostname="$DCU_REPORT_REAL_HOSTNAME"
+    [ -n "$DCU_REPORT_REAL_IP" ]                && primary_IPaddress="$DCU_REPORT_REAL_IP"
+    [ -n "$DCU_REPORT_REAL_DOCKER_VERSION" ]    && docker_version="$DCU_REPORT_REAL_DOCKER_VERSION"
+    
     if [ "$report_available" == true ]; then
         message+="🐳 *DOCKER CONTAINER UPDATE REPORT*\n"
         message+="\n"
@@ -2178,6 +2183,10 @@ Send-MailNotification() {
     local docker_version=$($cmd_docker --version | $cmd_cut -d ' ' -f3 | tr -d ',')
     local end_time=$(date +%s)
     stats_execution_time=$((end_time - start_time))
+
+    [ -n "$DCU_REPORT_REAL_HOSTNAME" ]          && hostname="$DCU_REPORT_REAL_HOSTNAME"
+    [ -n "$DCU_REPORT_REAL_IP" ]                && primary_IPaddress="$DCU_REPORT_REAL_IP"
+    [ -n "$DCU_REPORT_REAL_DOCKER_VERSION" ]    && docker_version="$DCU_REPORT_REAL_DOCKER_VERSION"
 
     if [[ "$report_available" == true && -n "$mail_from" && -n "$mail_recipients" && -n "$mail_subject" ]]; then
 


### PR DESCRIPTION
Implemented functionality to retrieve and display the Docker host's information (hostname, IP address, and Docker version) in the reports when running the Docker Container Updater as a Docker container by passing this information via the environment variables `DCU_REPORT_REAL_HOSTNAME`, `DCU_REPORT_REAL_IP` and `DCU_REPORT_REAL_DOCKER_VERSION`.